### PR TITLE
Now enter is not necessary to be pressed.

### DIFF
--- a/visualMarks.vim
+++ b/visualMarks.vim
@@ -31,9 +31,9 @@
 
 " Here we go.
 
+let g:filen = "/home/steven/.vim-vis-mark"
 " This is the function setting a mark, called from visual mode.
 function! VisualMark() "{{{
-
     " get the mark ID
     let mark = GetVisualMarkInput("mark selection ")
 
@@ -45,22 +45,22 @@ function! VisualMark() "{{{
     normal! o
     let [endLine, endCol] = [line('.'), col('.')]
 
-    let output = register . " " . startLine . " " . startCol . " " . endLine . " " . endCol
+    let output = [mark . " " . startLine . " " . startCol . " " . endLine . " " . endCol]
 
-    for line in readfile("/home/steven/.vim-vis-mark", " ")
+    for line in readfile(g:filen, " ")
       "If the first character of the line is the mark, then delete it from the
       "list because we are about to add a new definition for that mark
+      "TODO Do this with writeline, or some other way, as opening a buffer is
+      "slow
       if line[0] =~ mark
         new ~/.vim-vis-mark
-        exec "normal! /^" . register . ".\\+\<cr>dd"
+        exec "normal! /^" . mark . ".\\+\<cr>dd"
         :wq
       endif
     endfor
     "Add the new mark definition to the file
-    new ~/.vim-vis-mark
-    put =output
-    :wq
-  endfun
+    call writefile(readfile(g:filen)+output, g:filen)
+endfun
 "}}}
 
 " This is the function retrieving a marked selection, called from normal mode.
@@ -69,7 +69,7 @@ function! GetVisualMark() "{{{
     let mark = GetVisualMarkInput("restore selection ")
 
     "get pos from file
-    for line in readfile("/home/steven/.vim-vis-mark", " ")
+    for line in readfile(g:filen, " ")
       "if the register value is the firt character on the line
       if line[0] =~ mark
         "This creates a list of the 5 different values saved in the file


### PR DESCRIPTION
Hi, this is Steven Hall. I had provided a starting point on stack overflow for this project.

I found a way to get rid of the need to press enter, which I have in this pull request. It did also remove some trailing whitespaces because my vimrc does that automatically for me...

Also, If you go to my [vimrc](https://github.com/hallzy/dotfiles/blob/master/.vimrc) I have also made some additions since I last posted that gives persistence, where it writes to a file... as I am writing this, this feature is on the bottom of my vimrc.

Feel free to add the parts to make it persistent, or if you would rather, I can do it.

I should note, that it is persistent, but it does not check files, so the marks will be the same across multiple files, and if you write a mark to register a (for example), and then in a different file to the same, it will be overwritten (I do also have overwrite functionality in it so that you do not get duplicate entries).

The data is stored in the form:
"register character" "start line" "start col" "end line" "end col"
