### PR TITLE
Added the feature to save the visual mode in the dictionary.

### DIFF
--- a/visualMarks.vim
+++ b/visualMarks.vim
@@ -29,8 +29,6 @@
 "   - avoid saving and reading the dictionnary on each call to the functions.
 "     Better use an `autocmd VimEnter, VimLeave`? Yet it would be less safe?
 "     Does it slow the process down that much?
-"   - save the type of visual mode? (v, V, <c-v>) (might be some more work since
-"     3 positions are needed to save a <c-v> block)
 " DONE:
 "   - use and save/read a `dictionnary`
 "   - warn the user when trying to get a unexistent mark
@@ -43,6 +41,7 @@
 "   - choose whether or not leaving visual mode after having set a mark
 "   - make the warning softer
 "   - optional file location for the file
+"   - save the type of visual mode? (v, V, <c-v>)
 "
 " This DOES begin to look like something! :)
 

--- a/visualMarks.vim
+++ b/visualMarks.vim
@@ -96,6 +96,16 @@ function! VisualMark() "{{{
 
     " retrieve the position starting the selection
     normal! gvo
+    let currentmode = mode()
+    " if currentmode == "\<C-V>"
+    "   echom "Block Visual"
+    " elseif currentmode == "V"
+    "   echom "Line Visual"
+    " elseif currentmode == "v"
+    "   echom "Character Visual"
+    " else
+    "   echom "This should never happen"
+    " endif
     let [startLine, startCol] = [line('.'), col('.')]
 
     " retrieve the position ending the selection

--- a/visualMarks.vim
+++ b/visualMarks.vim
@@ -97,15 +97,15 @@ function! VisualMark() "{{{
     " retrieve the position starting the selection
     normal! gvo
     let currentmode = mode()
-    " if currentmode == "\<C-V>"
-    "   echom "Block Visual"
-    " elseif currentmode == "V"
-    "   echom "Line Visual"
-    " elseif currentmode == "v"
-    "   echom "Character Visual"
-    " else
-    "   echom "This should never happen"
-    " endif
+    " This comparison is case-insensitive
+    if currentmode ==? "\<C-V>"
+      let visualMode = "blk_vis"
+    "This comparison is case-sensitive
+    elseif currentmode ==# "V"
+      let visualMode = "line_vis"
+    else
+      let visualMode = "char_vis"
+    endif
     let [startLine, startCol] = [line('.'), col('.')]
 
     " retrieve the position ending the selection
@@ -114,7 +114,7 @@ function! VisualMark() "{{{
 
     " do whatever the user likes
     if g:visualMarks_exitVModeAfterMarking
-        normal! v
+        exec "normal! \<esc>"
     endif
 
     " update the dictionnary:
@@ -123,7 +123,7 @@ function! VisualMark() "{{{
         let g:visualMarks[filePath] = {}
     endif
     " and fill it up!
-    let g:visualMarks[filePath][mark] = [startLine, startCol, endLine, endCol]
+    let g:visualMarks[filePath][mark] = [startLine, startCol, endLine, endCol, visualMode]
 
     " and save it to the file. But I am sure we don't need to do this each time.
     call SaveVariable(g:visualMarks, g:filen)
@@ -156,11 +156,17 @@ function! GetVisualMark() "{{{
         let coordinates = g:visualMarks[filePath][mark]
         "move to the start pos, go to visual mode, and go to the end pos
         " + recursively open folds, just enough to see the selection
-        call cursor(coordinates[2], coordinates[3])
+        " call cursor(coordinates[2], coordinates[3])
         normal! zv
         call cursor(coordinates[0], coordinates[1])
         "enter visual mode to select the rest
-        exec "normal! zvv"
+        if coordinates[4] ==? "blk_vis"
+          exec "normal! zv\<c-v>"
+        elseif coordinates[4] ==? "line_vis"
+          exec "normal! zvV"
+        else
+          exec "normal! zvv"
+        endif
         call cursor(coordinates[2], coordinates[3])
     endif
 

--- a/visualMarks.vim
+++ b/visualMarks.vim
@@ -26,11 +26,15 @@
 "   - utility functions to clean the dictionnary, change filenames, move files,
 "     etc. (truly needed?)
 "   - make all this a Pathogen-friendly Vim plugin? (I have no idea how to do)
-"   - avoid saving and reading the dictionnary on each call to the functions.
+"   - avoid saving and reading the dictionary on each call to the functions.
 "     Better use an `autocmd VimEnter, VimLeave`? Yet it would be less safe?
 "     Does it slow the process down that much?
+"   - Adjust the script so that this feature also works for unnamed buffers. It
+"     might be good to make it such that when all unnamed buffers that were
+"     open are now closed, that we remove these entries from the vim-vis-mark
+"     file.
 " DONE:
-"   - use and save/read a `dictionnary`
+"   - use and save/read a `dictionary`
 "   - warn the user when trying to get a unexistent mark
 "   - make the marks specific to each file.
 "   - merged hallzy-master

--- a/visualMarks.vim
+++ b/visualMarks.vim
@@ -153,15 +153,15 @@ function! GetVisualMark() "{{{
     else
         " Then we can safely get back to this selection!
         let coordinates = g:visualMarks[filePath][mark]
+        let visualMode = coordinates[4]
         "move to the start pos, go to visual mode, and go to the end pos
         " + recursively open folds, just enough to see the selection
-        " call cursor(coordinates[2], coordinates[3])
         normal! zv
         call cursor(coordinates[0], coordinates[1])
         "enter visual mode to select the rest
-        if coordinates[4] ==? "blk_vis"
+        if visualMode ==? "blk_vis"
           exec "normal! zv\<c-v>"
-        elseif coordinates[4] ==? "line_vis"
+        elseif visualMode ==? "line_vis"
           exec "normal! zvV"
         else
           exec "normal! zvv"


### PR DESCRIPTION
I have added some lines that would provide a starting point for saving the specific type of visual mode... It only echos the visual type that it is in at the moment because I cant really work on it right now, but it is a good place to start.

All the lines are commented right now so that it does not impact the performance of what we have (the echoes require the press of the enter key to continue), so this change does not change anything about the way that the script will behave or run unless you uncomment the lines.
